### PR TITLE
Race, syntax, and deadlock

### DIFF
--- a/slide13.go
+++ b/slide13.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"sync"
 	"time"
 )
@@ -24,7 +25,7 @@ func MakeEggs(done *Done) {
 }
 
 type Done struct {
-	List string
+	List []string
 	Lock sync.Mutex
 }
 
@@ -35,8 +36,8 @@ func (d *Done) Append(item string) {
 }
 
 func main() {
-	var done Done
-	MakeCoffee(done)
-	MakeEggs(done)
-	MakeToast(done)
+	var done Done = Done{List: make([]string, 0)}
+	MakeCoffee(&done)
+	MakeEggs(&done)
+	MakeToast(&done)
 }

--- a/slide15.go
+++ b/slide15.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"log"
 	"time"
 )
 
@@ -33,9 +34,9 @@ func Gather(done chan string) []string {
 
 func main() {
 	doneCh := make(chan string)
-	MakeCoffee(doneCh)
-	MakeToast(doneCh)
-	MakeEggs(doneCh)
-	_ = Gather(doneCh)
-
+	go MakeCoffee(doneCh)
+	go MakeToast(doneCh)
+	go MakeEggs(doneCh)
+	doneList := Gather(doneCh)
+	log.Println(doneList)
 }

--- a/slide9.go
+++ b/slide9.go
@@ -34,12 +34,12 @@ func fanIn(chs ...chan string) chan string {
 	var wg sync.WaitGroup
 	for _, ch := range chs {
 		wg.Add(1)
-		go func() {
+		go func(ch chan string) {
 			defer wg.Done()
 			for msg := range ch {
 				fannedIn <- msg
 			}
-		}()
+		}(ch)
 	}
 	go func() {
 		wg.Wait()


### PR DESCRIPTION
Thanks so much for your talk at Denver Gophers Cammie! I found a few things I wanted to bring to your attention.

I ran all the slide.go files with race detector and found that slide9.go suffered from closing over a loop iteration variable. [Common Mistakes](https://github.com/golang/go/wiki/CommonMistakes)

Also slide13.go had a couple of syntax errors where List wasn't a slice of strings, and the function arguments expected *Done instead of Done types.

slide15.go blocked forever because it was writing to an unbuffered channel without using goroutines, so the program blocked forever on the 1st write into the channel. I made all the "Make" functions run inside goroutines.
